### PR TITLE
Preserve comments when adding new code

### DIFF
--- a/lib/factory/value.js
+++ b/lib/factory/value.js
@@ -1,9 +1,17 @@
 var esprima = require('esprima');
-
+var escodegen = require('escodegen');
 var Literal = require('../nodes/Literal.js');
 var ObjectExpression = require('../nodes/ObjectExpression.js');
 var FunctionExpression = require('../nodes/FunctionExpression.js');
 var ArrayExpression = require('../nodes/ArrayExpression.js');
+
+var esprimaOptions = {
+  comment: true,
+  range: true,
+  loc: false,
+  tokens: true,
+  raw: false
+};
 
 
 /**
@@ -12,7 +20,8 @@ var ArrayExpression = require('../nodes/ArrayExpression.js');
  * @return {Object}        Value node
  */
 exports.create = function (valStr) {
-  var tree = esprima.parse('var astValFactory = ' + valStr);
+  var tree = esprima.parse('var astValFactory = ' + valStr,esprimaOptions);
+  tree = escodegen.attachComments(tree, tree.comments, tree.tokens);
   return tree.body[0].declarations[0].init;
 };
 

--- a/test/nodes/variable.js
+++ b/test/nodes/variable.js
@@ -50,4 +50,12 @@ describe('Variable objects', function () {
       assert.equal(this.tree1.toString(), 'var foo = 1;');
     });
   });
+
+  describe('#toString()', function() {
+   it('should preserve comments when assigning new values', function() {
+       this.tree1.var('a').value('{/* some comments */ foo: "bar" }');
+       assert.equal(this.tree1.toString().replace(/[\r\n\t\s]+/gm,''), 'vara={/*somecomments*/foo:\'bar\'};');
+   });
+  });
+
 });


### PR DESCRIPTION
Hey, 
i forgot to fix comments when adding new code to the AST. Fixed this.
Only missing comments when using `body.append` and `body.prepend`.
I'll send another PR when i figured out how to prevent comments getting stripped for these methods
