### PR TITLE
Add the ability to specify escodegen options when creating a Tree

### DIFF
--- a/lib/tree.js
+++ b/lib/tree.js
@@ -29,7 +29,7 @@ function Tree(source, options) {
   this.tree = esprima.parse(source.toString(), esprimaOptions);
   this.tree = escodegen.attachComments(this.tree, this.tree.comments, this.tree.tokens);
   this.body = new Body(this.tree.body);
-  this.escodegenOptions = _.merge(_.merge({}, escodegenOptions), options);
+  this.escodegenOptions = _.merge({}, escodegenOptions, options);
 }
 
 /**

--- a/test/tree.js
+++ b/test/tree.js
@@ -36,7 +36,7 @@ describe('Tree', function () {
 
   describe('created with tab formatting option', function () {
     it('return the generated source code', function () {
-      var tree = program('(function () {\n\tconsole.log("foo");\n\tconsole.log("bar");\n})();', {
+      var tree = program('(function () {\n  console.log("foo");\n  console.log("bar");\n})();', {
         format: {
           indent: {
             style: '\t'


### PR DESCRIPTION
For my projects, I use a different code style from the default defined for AST-query. This pull request adds an `options` parameter to the `Tree` constructor to provide options to override the defaults.
