### PR TITLE
ObjectExpressions have a 'properties' not 'property' property

### DIFF
--- a/lib/nodes/ObjectExpression.js
+++ b/lib/nodes/ObjectExpression.js
@@ -55,7 +55,7 @@ var ObjectExpression = module.exports = Base.extend({
 
     // As we don't keep reference to the parent, just update properties so the object stay
     // the same reference.
-    delete this.node.property;
+    delete this.node.properties;
     delete this.node.type;
     this.node.TEMP = false;
     _.extend(this.node, val);


### PR DESCRIPTION
Delete ```this.properties```, not ```this.property```