### PR TITLE
Added esprimaOptions to Body

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Program
 ### `var tree = program( sourceCode, escodegenOptions, esprimaOptions )`
 - **sourceCode** (String) - The source code to edit.
 - **escodegenOptions** (Object) _optional_ - [escodegen](https://github.com/Constellation/escodegen) option object
-- **esprimaOptions** (Object) _optional_ - object[esprima](http://esprima.org/doc) option
+- **esprimaOptions** (Object) _optional_ - [esprima](http://esprima.org/doc) object option
 
 Returns an AST tree you can then query as explained below:
 

--- a/lib/nodes/Body.js
+++ b/lib/nodes/Body.js
@@ -6,9 +6,11 @@ var esprima = require('esprima');
  * @constructor
  * @private
  * @param {Object} node
+ * @param {Object} esprimaOptions
  */
-var Body = module.exports = function (node) {
+var Body = module.exports = function (node, esprimaOptions) {
   this.node = node;
+  this.esprimaOptions = esprimaOptions;
 };
 
 /**
@@ -17,7 +19,7 @@ var Body = module.exports = function (node) {
  * @return {this}
  */
 Body.prototype.append = function (code) {
-  var values = esprima.parse(code).body;
+  var values = esprima.parse(code, this.esprimaOptions).body;
   Array.prototype.push.apply(this.node, values);
   return this;
 };
@@ -28,7 +30,7 @@ Body.prototype.append = function (code) {
  * @return {this}
  */
 Body.prototype.prepend = function (code) {
-  var values = esprima.parse(code).body;
+  var values = esprima.parse(code, this.esprimaOptions).body;
   var insertionIndex = 0;
   var nodes = this.node;
 

--- a/lib/tree.js
+++ b/lib/tree.js
@@ -30,7 +30,7 @@ function Tree(source, escodegenOptions, esprimaOptions) {
   this.esprimaOptionDefaults = _.merge({}, esprimaOptionDefaults, esprimaOptions);
   this.tree = esprima.parse(source.toString(), this.esprimaOptionDefaults);
   this.tree = escodegen.attachComments(this.tree, this.tree.comments, this.tree.tokens);
-  this.body = new Body(this.tree.body);
+  this.body = new Body(this.tree.body, this.esprimaOptionDefaults);
   this.escodegenOptions = _.merge({}, escodegenOptionDefaults, escodegenOptions);
 }
 


### PR DESCRIPTION
Esprima options were added so that ES2015 features can be appended.  Without this change it is not possible to append/prepend ES2015 code (import & export statements).