### PR TITLE
Allow query to be applied to an ast with Tree.fromTree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+*.DS_Store
 node_modules/

--- a/lib/tree.js
+++ b/lib/tree.js
@@ -23,17 +23,40 @@ var escodegenOptionDefaults = {
   }
 };
 
-function Tree(source, escodegenOptions, acornOptions) {
-  this.acornOptionDefaults = _.extend({}, acornOptionDefaults, acornOptions);
-  this.comments = [];
-  this.tokens = [];
-  this.acornOptionDefaults.onComment = this.comments;
-  this.acornOptionDefaults.onToken = this.tokens;
-  this.tree = acorn.parse(source.toString(), this.acornOptionDefaults);
-  this.tree = escodegen.attachComments(this.tree, this.comments, this.tokens);
-  this.body = new Body(this.tree.body, this.acornOptionDefaults);
-  this.escodegenOptions = _.extend({}, escodegenOptionDefaults, escodegenOptions);
-}
+var Tree = module.exports = function Tree() {
+  this.acornOptions = undefined;
+  this.comments = undefined;
+  this.tree = undefined;
+  this.body = undefined;
+  this.escodegenOptions = undefined;
+};
+
+Tree.fromSource = function(source, escodegenOptions, acornOptions) {
+  var instance = new Tree();
+  instance.acornOptions = _.extend({}, acornOptionDefaults, acornOptions);
+  instance.comments = [];
+  instance.tokens = [];
+  instance.acornOptions.onComment = instance.comments;
+  instance.acornOptions.onToken = instance.tokens;
+  instance.tree = acorn.parse(source.toString(), instance.acornOptions);
+  instance.tree = escodegen.attachComments(instance.tree, instance.comments, instance.tokens);
+  instance.body = new Body(instance.tree.body, instance.acornOptions);
+  instance.escodegenOptions = _.extend({}, escodegenOptionDefaults, escodegenOptions);
+  return instance;
+};
+
+Tree.fromTree = function(tree, escodegenOptions, acornOptions) {
+  var instance = new Tree();
+  instance.acornOptions = _.extend({}, acornOptionDefaults, acornOptions);
+  instance.comments = [];
+  instance.tokens = [];
+  instance.acornOptions.onComment = instance.comments;
+  instance.acornOptions.onToken = instance.tokens;
+  instance.tree = tree;
+  instance.body = new Body(instance.tree.body, instance.acornOptions);
+  instance.escodegenOptions = _.extend({}, escodegenOptionDefaults, escodegenOptions);
+  return instance;
+};
 
 /**
  * Return the regenerated code string
@@ -109,8 +132,4 @@ Tree.prototype.verbatim = function (body) {
   var token = 'tok' + verbatimId.toString();
   Body.verbatims[token] = body;
   return '\'' + token + '\';';
-};
-
-module.exports = function (source, escodegenOptions, acornOptions) {
-  return new Tree(source, escodegenOptions, acornOptions);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1226 @@
+{
+  "name": "ast-query",
+  "version": "2.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true
+    },
+    "acorn": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+      "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ=="
+    },
+    "acorn-jsx": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-4.1.1.tgz",
+      "integrity": "sha512-JY+iV6r+cO21KtntVvFkD+iqjtdpRUpGqKWgfkCdZq1R+kbreEl8EcdcJR4SmiIgsIQT33s6QzheQ9a275Q8xw==",
+      "requires": {
+        "acorn": "5.5.3"
+      }
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "optional": true
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "1.0.3"
+      },
+      "dependencies": {
+        "sprintf-js": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+          "dev": true
+        }
+      }
+    },
+    "array-find-index": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+      "dev": true
+    },
+    "async": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
+    "builtin-modules": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "dev": true
+    },
+    "camelcase": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+      "dev": true
+    },
+    "camelcase-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+      "dev": true,
+      "requires": {
+        "camelcase": "2.1.1",
+        "map-obj": "1.0.1"
+      }
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      }
+    },
+    "class-extend": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/class-extend/-/class-extend-0.1.2.tgz",
+      "integrity": "sha1-gFeoKwD1P4Kl1ixQ74z/3sb6vDQ=",
+      "requires": {
+        "object-assign": "2.1.1"
+      }
+    },
+    "cli": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
+      "integrity": "sha1-IoF1NPJL+klQw01TLUjsvGIbjBQ=",
+      "dev": true,
+      "requires": {
+        "exit": "0.1.2",
+        "glob": "7.1.2"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        }
+      }
+    },
+    "coffeescript": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-1.10.0.tgz",
+      "integrity": "sha1-56qDAZF+9iGzXYo580jc3R234z4=",
+      "dev": true
+    },
+    "colors": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+      "dev": true
+    },
+    "commander": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "console-browserify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+      "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+      "dev": true,
+      "requires": {
+        "date-now": "0.1.4"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "currently-unhandled": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+      "dev": true,
+      "requires": {
+        "array-find-index": "1.0.2"
+      }
+    },
+    "date-now": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+      "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
+      "dev": true
+    },
+    "dateformat": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
+      "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
+      "dev": true,
+      "requires": {
+        "get-stdin": "4.0.1",
+        "meow": "3.7.0"
+      }
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
+    },
+    "dom-serializer": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+      "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1.1.3",
+        "entities": "1.1.1"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
+          "dev": true
+        },
+        "entities": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+          "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
+          "dev": true
+        }
+      }
+    },
+    "domelementtype": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
+      "dev": true
+    },
+    "domhandler": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+      "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1.3.0"
+      }
+    },
+    "domutils": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+      "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+      "dev": true,
+      "requires": {
+        "dom-serializer": "0.1.0",
+        "domelementtype": "1.3.0"
+      }
+    },
+    "entities": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+      "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
+      "dev": true
+    },
+    "error-ex": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "0.2.1"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "escodegen-wallaby": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/escodegen-wallaby/-/escodegen-wallaby-1.6.18.tgz",
+      "integrity": "sha512-3UvR14JRNh8VfKJixTDHWmhPNKAJiVZS807KUjECBk6f05WMe8ZeWL1gbrswNYhDiAUeDBQccyTWR91fayx3og==",
+      "requires": {
+        "esprima": "2.7.3",
+        "estraverse": "1.9.3",
+        "esutils": "2.0.2",
+        "optionator": "0.8.2",
+        "source-map": "0.2.0"
+      }
+    },
+    "esprima": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+    },
+    "estraverse": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+      "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q="
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+    },
+    "eventemitter2": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+      "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
+      "dev": true
+    },
+    "exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+    },
+    "find-up": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "dev": true,
+      "requires": {
+        "path-exists": "2.1.0",
+        "pinkie-promise": "2.0.1"
+      }
+    },
+    "findup-sync": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
+      "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
+      "dev": true,
+      "requires": {
+        "glob": "5.0.15"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "dev": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        }
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "get-stdin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+      "dev": true
+    },
+    "getobject": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
+      "integrity": "sha1-BHpEl4n6Fg0Bj1SG7ZEyC27HiFw=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
+      "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+      "dev": true
+    },
+    "grunt": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.0.2.tgz",
+      "integrity": "sha1-TmpeaVtwRy/VME9fqeNCNoNqc7w=",
+      "dev": true,
+      "requires": {
+        "coffeescript": "1.10.0",
+        "dateformat": "1.0.12",
+        "eventemitter2": "0.4.14",
+        "exit": "0.1.2",
+        "findup-sync": "0.3.0",
+        "glob": "7.0.6",
+        "grunt-cli": "1.2.0",
+        "grunt-known-options": "1.1.0",
+        "grunt-legacy-log": "1.0.1",
+        "grunt-legacy-util": "1.0.0",
+        "iconv-lite": "0.4.19",
+        "js-yaml": "3.5.5",
+        "minimatch": "3.0.4",
+        "nopt": "3.0.6",
+        "path-is-absolute": "1.0.1",
+        "rimraf": "2.2.8"
+      }
+    },
+    "grunt-cli": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-1.2.0.tgz",
+      "integrity": "sha1-VisRnrsGndtGSs4oRVAb6Xs1tqg=",
+      "dev": true,
+      "requires": {
+        "findup-sync": "0.3.0",
+        "grunt-known-options": "1.1.0",
+        "nopt": "3.0.6",
+        "resolve": "1.1.7"
+      }
+    },
+    "grunt-contrib-jshint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-1.1.0.tgz",
+      "integrity": "sha1-Np2QmyWTxA6L55lAshNAhQx5Oaw=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "hooker": "0.2.3",
+        "jshint": "2.9.5"
+      }
+    },
+    "grunt-known-options": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/grunt-known-options/-/grunt-known-options-1.1.0.tgz",
+      "integrity": "sha1-pCdO6zL6dl2lp6OxcSYXzjsUQUk=",
+      "dev": true
+    },
+    "grunt-legacy-log": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-1.0.1.tgz",
+      "integrity": "sha512-rwuyqNKlI0IPz0DvxzJjcEiQEBaBNVeb1LFoZKxSmHLETFUwhwUrqOsPIxURTKSwNZHZ4ht1YLBYmVU0YZAzHQ==",
+      "dev": true,
+      "requires": {
+        "colors": "1.1.2",
+        "grunt-legacy-log-utils": "1.0.0",
+        "hooker": "0.2.3",
+        "lodash": "4.17.5",
+        "underscore.string": "3.3.4"
+      }
+    },
+    "grunt-legacy-log-utils": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-1.0.0.tgz",
+      "integrity": "sha1-p7ji0Ps1taUPSvmG/BEnSevJbz0=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "lodash": "4.3.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.3.0.tgz",
+          "integrity": "sha1-79nEpuxT87BUEkKZFcPkgk5NJaQ=",
+          "dev": true
+        }
+      }
+    },
+    "grunt-legacy-util": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-1.0.0.tgz",
+      "integrity": "sha1-OGqnjcbtUJhsKxiVcmWxtIq7m4Y=",
+      "dev": true,
+      "requires": {
+        "async": "1.5.2",
+        "exit": "0.1.2",
+        "getobject": "0.1.0",
+        "hooker": "0.2.3",
+        "lodash": "4.3.0",
+        "underscore.string": "3.2.3",
+        "which": "1.2.14"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.3.0.tgz",
+          "integrity": "sha1-79nEpuxT87BUEkKZFcPkgk5NJaQ=",
+          "dev": true
+        },
+        "underscore.string": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.2.3.tgz",
+          "integrity": "sha1-gGmSYzZl1eX8tNsfs6hi62jp5to=",
+          "dev": true
+        }
+      }
+    },
+    "grunt-simple-mocha": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/grunt-simple-mocha/-/grunt-simple-mocha-0.4.1.tgz",
+      "integrity": "sha1-V5RJJJ6vCoGHj6cvPtq1FF1F/Xc=",
+      "dev": true,
+      "requires": {
+        "mocha": "5.0.5"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "has-flag": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+      "dev": true
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "hooker": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+      "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk=",
+      "dev": true
+    },
+    "hosted-git-info": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
+      "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
+      "dev": true
+    },
+    "htmlparser2": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+      "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1.3.0",
+        "domhandler": "2.3.0",
+        "domutils": "1.5.1",
+        "entities": "1.0.0",
+        "readable-stream": "1.1.14"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+      "dev": true
+    },
+    "indent-string": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+      "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+      "dev": true,
+      "requires": {
+        "repeating": "2.0.1"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "is-builtin-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+      "dev": true,
+      "requires": {
+        "builtin-modules": "1.1.1"
+      }
+    },
+    "is-finite": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
+    },
+    "is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "dev": true
+    },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.5.5.tgz",
+      "integrity": "sha1-A3fDgBfKvHMisNH7zSWkkWQfL74=",
+      "dev": true,
+      "requires": {
+        "argparse": "1.0.10",
+        "esprima": "2.7.3"
+      }
+    },
+    "jshint": {
+      "version": "2.9.5",
+      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.9.5.tgz",
+      "integrity": "sha1-HnJSkVzmgbQIJ+4UJIxG006apiw=",
+      "dev": true,
+      "requires": {
+        "cli": "1.0.1",
+        "console-browserify": "1.1.0",
+        "exit": "0.1.2",
+        "htmlparser2": "3.8.3",
+        "lodash": "3.7.0",
+        "minimatch": "3.0.4",
+        "shelljs": "0.3.0",
+        "strip-json-comments": "1.0.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "3.7.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz",
+          "integrity": "sha1-Nni9irmVBXwHreg27S7wh9qBHUU=",
+          "dev": true
+        }
+      }
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "requires": {
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
+      }
+    },
+    "load-json-file": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "strip-bom": "2.0.0"
+      }
+    },
+    "lodash": {
+      "version": "4.17.5",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+    },
+    "loud-rejection": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+      "dev": true,
+      "requires": {
+        "currently-unhandled": "0.4.1",
+        "signal-exit": "3.0.2"
+      }
+    },
+    "map-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+      "dev": true
+    },
+    "meow": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+      "dev": true,
+      "requires": {
+        "camelcase-keys": "2.1.0",
+        "decamelize": "1.2.0",
+        "loud-rejection": "1.6.0",
+        "map-obj": "1.0.1",
+        "minimist": "1.2.0",
+        "normalize-package-data": "2.4.0",
+        "object-assign": "4.1.1",
+        "read-pkg-up": "1.0.1",
+        "redent": "1.0.0",
+        "trim-newlines": "1.0.0"
+      },
+      "dependencies": {
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "dev": true
+        }
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.11"
+      }
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        }
+      }
+    },
+    "mocha": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.0.5.tgz",
+      "integrity": "sha512-3MM3UjZ5p8EJrYpG7s+29HAI9G7sTzKEe4+w37Dg0QP7qL4XGsV+Q2xet2cE37AqdgN1OtYQB6Vl98YiPV3PgA==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.1",
+        "commander": "2.11.0",
+        "debug": "3.1.0",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.3",
+        "he": "1.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "4.4.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "supports-color": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "nopt": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "dev": true,
+      "requires": {
+        "abbrev": "1.1.1"
+      }
+    },
+    "normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "2.6.0",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.5.0",
+        "validate-npm-package-license": "3.0.3"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
+    },
+    "object-assign": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+      "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "requires": {
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
+      }
+    },
+    "parse-json": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "dev": true,
+      "requires": {
+        "error-ex": "1.3.1"
+      }
+    },
+    "path-exists": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "dev": true,
+      "requires": {
+        "pinkie-promise": "2.0.1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-type": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      }
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "2.0.4"
+      }
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+    },
+    "read-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "dev": true,
+      "requires": {
+        "load-json-file": "1.1.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "1.1.0"
+      }
+    },
+    "read-pkg-up": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "dev": true,
+      "requires": {
+        "find-up": "1.1.2",
+        "read-pkg": "1.1.0"
+      }
+    },
+    "readable-stream": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+      "dev": true,
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "0.0.1",
+        "string_decoder": "0.10.31"
+      }
+    },
+    "redent": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+      "dev": true,
+      "requires": {
+        "indent-string": "2.1.0",
+        "strip-indent": "1.0.1"
+      }
+    },
+    "repeating": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "dev": true,
+      "requires": {
+        "is-finite": "1.0.2"
+      }
+    },
+    "resolve": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+      "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+      "dev": true
+    },
+    "rimraf": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+      "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
+      "dev": true
+    },
+    "semver": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+      "dev": true
+    },
+    "shelljs": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+      "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "source-map": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+      "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+      "optional": true,
+      "requires": {
+        "amdefine": "1.0.1"
+      }
+    },
+    "spdx-correct": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+      "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "3.0.0",
+        "spdx-license-ids": "3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+      "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "2.1.0",
+        "spdx-license-ids": "3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
+      "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
+      "dev": true
+    },
+    "sprintf-js": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.1.tgz",
+      "integrity": "sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw=",
+      "dev": true
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "strip-bom": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+      "dev": true,
+      "requires": {
+        "is-utf8": "0.2.1"
+      }
+    },
+    "strip-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+      "dev": true,
+      "requires": {
+        "get-stdin": "4.0.1"
+      }
+    },
+    "strip-json-comments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+      "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true
+    },
+    "traverse": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
+    },
+    "trim-newlines": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+      "dev": true
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "requires": {
+        "prelude-ls": "1.1.2"
+      }
+    },
+    "underscore.string": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz",
+      "integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s=",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "1.1.1",
+        "util-deprecate": "1.0.2"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
+      "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "3.0.0",
+        "spdx-expression-parse": "3.0.0"
+      }
+    },
+    "which": {
+      "version": "1.2.14",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+      "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
+      "dev": true,
+      "requires": {
+        "isexe": "2.0.0"
+      }
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    }
+  }
+}

--- a/test/nodes/ArrayExpression.js
+++ b/test/nodes/ArrayExpression.js
@@ -1,67 +1,76 @@
 var assert = require('assert');
-var program = require('../../');
 var valueFactory = require('../../lib/factory/value.js');
 
 var ObjectExpression = require('../../lib/nodes/ObjectExpression.js');
 var ArrayExpression = require('../../lib/nodes/ArrayExpression.js');
 var Literal = require('../../lib/nodes/Literal.js');
 
-describe('ArrayExpression objects', function () {
-  beforeEach(function () {
-    this.arr = new ArrayExpression(valueFactory.create('[1, [2, 3], "a", {"foo":"bar"}, ]'));
-  });
+var Tree = require('../..');
 
-  it('#type equal ArrayExpression', function () {
-    assert.equal(this.arr.type, 'ArrayExpression');
-  });
-
-  describe('#push()', function () {
-    it('adds a new value to the end of the array', function () {
-      this.arr.at(1).push('"a"');
-      assert.equal(this.arr.at(1).at(1).value(), 3);
-      assert.equal(this.arr.at(1).at(2).value(), 'a');
-    });
-  });
-
-  describe('#unshift()', function () {
-    it('adds a new value to the start of the array', function () {
-      this.arr.at(1).unshift('"a"');
-      assert.equal(this.arr.at(1).at(0).value(), 'a');
-      assert.equal(this.arr.at(1).at(2).value(), 3);
-    });
-  });
-
-  describe('#at()', function () {
-    it('returns a wrapped value', function () {
-      assert(this.arr.at(0) instanceof Literal);
-      assert(this.arr.at(1) instanceof ArrayExpression);
-      assert(this.arr.at(1).at(0) instanceof Literal);
-      assert(this.arr.at(2) instanceof Literal);
-      assert(this.arr.at(3) instanceof ObjectExpression);
-
-      assert.equal(this.arr.at(0).value(), 1);
-      assert.equal(this.arr.at(1).at(0).value(), 2);
-      assert.equal(this.arr.at(2).value(), 'a');
-    });
-  });
-
-  describe('#value()', function () {
-    it('replace itself with new value', function () {
-      var tree = program('var b = ["a"];');
-      tree.var('b').value('[1]');
-      assert.equal(tree.toString(), 'var b = [1];');
+[
+  Tree.fromSource,
+  function() {
+    var tree = Tree.fromSource(arguments[0], arguments[1], arguments[2], arguments[3], arguments[4]);
+    return Tree.fromTree(tree.tree, arguments[1], arguments[2], arguments[3], arguments[4]);
+  },
+].forEach(function(program) {
+  describe('ArrayExpression objects', function () {
+    beforeEach(function () {
+      this.arr = new ArrayExpression(valueFactory.create('[1, [2, 3], "a", {"foo":"bar"}, ]'));
     });
 
-    it('replaces itself with a different type of node', function () {
-      var tree = program('var b = ["a"];');
-      tree.var('b').value('"this is literal"');
-      assert.equal(tree.toString(), 'var b = \'this is literal\';');
+    it('#type equal ArrayExpression', function () {
+      assert.equal(this.arr.type, 'ArrayExpression');
     });
 
-    it('return the new value', function () {
-      var val = this.arr.at(1).value('"a"');
-      assert(val instanceof Literal);
-      assert.equal(val.value(), 'a');
+    describe('#push()', function () {
+      it('adds a new value to the end of the array', function () {
+        this.arr.at(1).push('"a"');
+        assert.equal(this.arr.at(1).at(1).value(), 3);
+        assert.equal(this.arr.at(1).at(2).value(), 'a');
+      });
+    });
+
+    describe('#unshift()', function () {
+      it('adds a new value to the start of the array', function () {
+        this.arr.at(1).unshift('"a"');
+        assert.equal(this.arr.at(1).at(0).value(), 'a');
+        assert.equal(this.arr.at(1).at(2).value(), 3);
+      });
+    });
+
+    describe('#at()', function () {
+      it('returns a wrapped value', function () {
+        assert(this.arr.at(0) instanceof Literal);
+        assert(this.arr.at(1) instanceof ArrayExpression);
+        assert(this.arr.at(1).at(0) instanceof Literal);
+        assert(this.arr.at(2) instanceof Literal);
+        assert(this.arr.at(3) instanceof ObjectExpression);
+
+        assert.equal(this.arr.at(0).value(), 1);
+        assert.equal(this.arr.at(1).at(0).value(), 2);
+        assert.equal(this.arr.at(2).value(), 'a');
+      });
+    });
+
+    describe('#value()', function () {
+      it('replace itself with new value', function () {
+        var tree = program('var b = ["a"];');
+        tree.var('b').value('[1]');
+        assert.equal(tree.toString(), 'var b = [1];');
+      });
+
+      it('replaces itself with a different type of node', function () {
+        var tree = program('var b = ["a"];');
+        tree.var('b').value('"this is literal"');
+        assert.equal(tree.toString(), 'var b = \'this is literal\';');
+      });
+
+      it('return the new value', function () {
+        var val = this.arr.at(1).value('"a"');
+        assert(val instanceof Literal);
+        assert.equal(val.value(), 'a');
+      });
     });
   });
 });

--- a/test/nodes/AssignmentExpression.js
+++ b/test/nodes/AssignmentExpression.js
@@ -1,37 +1,46 @@
 /*globals describe, it, beforeEach */
 var assert = require('assert');
-var program = require('../..');
 
 var AssignmentExpression = require('../../lib/nodes/AssignmentExpression.js');
 
-describe('AssignmentExpression objects', function () {
-  beforeEach(function () {
-    this.tree1 = program('a = 1;');
-    this.tree2 = program('module.export = 2;');
-    this.tree3 = program('some.deeply.nested.property = 3;');
-  });
+var Tree = require('../..');
 
-  it('selects assignment expression', function () {
-    assert.equal(this.tree1.assignment('a').length, 1);
-  });
+[
+  Tree.fromSource,
+  function() {
+    var tree = Tree.fromSource(arguments[0], arguments[1], arguments[2], arguments[3], arguments[4]);
+    return Tree.fromTree(tree.tree, arguments[1], arguments[2], arguments[3], arguments[4]);
+  },
+].forEach(function(program) {
+  describe('AssignmentExpression objects', function () {
+    beforeEach(function () {
+      this.tree1 = program('a = 1;');
+      this.tree2 = program('module.export = 2;');
+      this.tree3 = program('some.deeply.nested.property = 3;');
+    });
 
-  it('selects member assignment expression', function () {
-    assert.equal(this.tree2.assignment('module.export').length, 1);
-  });
+    it('selects assignment expression', function () {
+      assert.equal(this.tree1.assignment('a').length, 1);
+    });
 
-  it('selects member assignment from regex', function () {
-    assert.equal(this.tree2.assignment(/module/).length, 1);
-  });
+    it('selects member assignment expression', function () {
+      assert.equal(this.tree2.assignment('module.export').length, 1);
+    });
 
-  it('selects multi-member assignment from regex', function () {
-    assert.equal(this.tree3.assignment(/some\.[a-z]+\.[a-z]+/).length, 1);
-  });
+    it('selects member assignment from regex', function () {
+      assert.equal(this.tree2.assignment(/module/).length, 1);
+    });
 
-  describe('#value()', function () {
-    it('return the wrapped value', function () {
-      var val = this.tree1.assignment('a').value();
-      assert.equal(val.type, 'Literal');
-      assert.equal(val.value(), 1);
+    it('selects multi-member assignment from regex', function () {
+      assert.equal(this.tree3.assignment(/some\.[a-z]+\.[a-z]+/).length, 1);
+    });
+
+    describe('#value()', function () {
+      it('return the wrapped value', function () {
+        var val = this.tree1.assignment('a').value();
+        assert.equal(val.type, 'Literal');
+        assert.equal(val.value(), 1);
+      });
     });
   });
 });

--- a/test/nodes/FunctionExpression.js
+++ b/test/nodes/FunctionExpression.js
@@ -1,59 +1,68 @@
 /*globals describe, it, beforeEach */
 var assert = require('assert');
-var program = require('../..');
 var valueFactory = require('../../lib/factory/value.js');
 
 var FunctionExpression = require('../../lib/nodes/FunctionExpression.js');
 
-describe('FunctionExpression objects', function () {
-  beforeEach(function () {
-    this.func = program('var a = function () { "use strict"; }');
-    this.func2 = program('var a = function () { somecall(); }');
-    // Need more than 10 statements to test for #12
-    this.func3 = program('var a = function () { "use strict"; call(); call(); call(); call();' +
-      'call(); call(); call(); call(); call(); call();}');
-  });
+var Tree = require('../..');
 
-  it('#type is FunctionExpression', function () {
-    assert.equal(this.func.var('a').value().type, 'FunctionExpression');
-  });
-
-  describe('#body', function () {
-    describe('#append()', function () {
-      it('append code to the end of the function body', function () {
-        this.func2.var('a').value().body.append('callFunc()');
-        assert.equal(this.func2.toString(), 'var a = function () {\n    somecall();\n    callFunc();\n};');
-      });
-
-      it('append multiple lines', function () {
-        this.func.var('a').value().body.append('callFunc(); foo();');
-        assert.equal(this.func.toString(),
-          'var a = function () {\n    \'use strict\';\n    callFunc();\n    foo();\n};');
-      });
+[
+  Tree.fromSource,
+  function() {
+    var tree = Tree.fromSource(arguments[0], arguments[1], arguments[2], arguments[3], arguments[4]);
+    return Tree.fromTree(tree.tree, arguments[1], arguments[2], arguments[3], arguments[4]);
+  },
+].forEach(function(program) {
+  describe('FunctionExpression objects', function () {
+    beforeEach(function () {
+      this.func = program('var a = function () { "use strict"; }');
+      this.func2 = program('var a = function () { somecall(); }');
+      // Need more than 10 statements to test for #12
+      this.func3 = program('var a = function () { "use strict"; call(); call(); call(); call();' +
+        'call(); call(); call(); call(); call(); call();}');
     });
 
-    describe('#prepend()', function () {
-      it('prepend code the the beginning of a function body', function () {
-        this.func2.var('a').value().body.prepend('callFunc()');
-        assert.equal(this.func2.toString(), 'var a = function () {\n    callFunc();\n    somecall();\n};');
+    it('#type is FunctionExpression', function () {
+      assert.equal(this.func.var('a').value().type, 'FunctionExpression');
+    });
+
+    describe('#body', function () {
+      describe('#append()', function () {
+        it('append code to the end of the function body', function () {
+          this.func2.var('a').value().body.append('callFunc()');
+          assert.equal(this.func2.toString(), 'var a = function () {\n    somecall();\n    callFunc();\n};');
+        });
+
+        it('append multiple lines', function () {
+          this.func.var('a').value().body.append('callFunc(); foo();');
+          assert.equal(this.func.toString(),
+            'var a = function () {\n    \'use strict\';\n    callFunc();\n    foo();\n};');
+        });
       });
 
-      it('insert code after "use strict" statement', function () {
-        this.func.var('a').value().body.prepend('callFunc()');
-        assert.equal(this.func.toString(), 'var a = function () {\n    \'use strict\';\n    callFunc();\n};');
-      });
+      describe('#prepend()', function () {
+        it('prepend code the the beginning of a function body', function () {
+          this.func2.var('a').value().body.prepend('callFunc()');
+          assert.equal(this.func2.toString(), 'var a = function () {\n    callFunc();\n    somecall();\n};');
+        });
 
-      it('prepend multiple lines', function () {
-        this.func.var('a').value().body.prepend('callFunc(); foo();');
-        assert.equal(this.func.toString(),
-          'var a = function () {\n    \'use strict\';\n    callFunc();\n    foo();\n};');
-      });
+        it('insert code after "use strict" statement', function () {
+          this.func.var('a').value().body.prepend('callFunc()');
+          assert.equal(this.func.toString(), 'var a = function () {\n    \'use strict\';\n    callFunc();\n};');
+        });
 
-      it('insert code after "use strict" statement with a lot of other statements', function () {
-        this.func3.var('a').value().body.prepend('foo();');
-        assert.equal(this.func3.toString(),
-          'var a = function () {\n    \'use strict\';\n    foo();\n    call();\n    call();\n    call();\n' +
-          '    call();\n    call();\n    call();\n    call();\n    call();\n    call();\n    call();\n};');
+        it('prepend multiple lines', function () {
+          this.func.var('a').value().body.prepend('callFunc(); foo();');
+          assert.equal(this.func.toString(),
+            'var a = function () {\n    \'use strict\';\n    callFunc();\n    foo();\n};');
+        });
+
+        it('insert code after "use strict" statement with a lot of other statements', function () {
+          this.func3.var('a').value().body.prepend('foo();');
+          assert.equal(this.func3.toString(),
+            'var a = function () {\n    \'use strict\';\n    foo();\n    call();\n    call();\n    call();\n' +
+            '    call();\n    call();\n    call();\n    call();\n    call();\n    call();\n    call();\n};');
+        });
       });
     });
   });

--- a/test/nodes/Literal.js
+++ b/test/nodes/Literal.js
@@ -1,19 +1,28 @@
 var assert = require('assert');
-var program = require('../../');
 var valueFactory = require('../../lib/factory/value.js');
 
 var Literal = require('../../lib/nodes/Literal.js');
 
-describe('Literal nodes', function () {
-  beforeEach(function () {
-    this.tree = program('var a = 2;');
-  });
+var Tree = require('../..');
 
-  describe('#value', function () {
-    it('overwrite value', function () {
-      var literal = this.tree.var('a').value();
-      literal.value('{ a: 2 }');
-      assert.equal(this.tree.toString(), 'var a = { a: 2 };');
+[
+  Tree.fromSource,
+  function() {
+    var tree = Tree.fromSource(arguments[0], arguments[1], arguments[2], arguments[3], arguments[4]);
+    return Tree.fromTree(tree.tree, arguments[1], arguments[2], arguments[3], arguments[4]);
+  },
+].forEach(function(program) {
+  describe('Literal nodes', function () {
+    beforeEach(function () {
+      this.tree = program('var a = 2;');
+    });
+
+    describe('#value', function () {
+      it('overwrite value', function () {
+        var literal = this.tree.var('a').value();
+        literal.value('{ a: 2 }');
+        assert.equal(this.tree.toString(), 'var a = { a: 2 };');
+      });
     });
   });
 });

--- a/test/nodes/callexpression.js
+++ b/test/nodes/callexpression.js
@@ -1,94 +1,103 @@
 /*globals describe, it, beforeEach */
 var assert = require('assert');
-var program = require('../..');
 
 var ObjectExpression = require('../../lib/nodes/ObjectExpression.js');
 var Literal = require('../../lib/nodes/Literal.js');
 
-describe('CallExpression objects', function () {
-  beforeEach(function () {
-    this.tree1 = program('foo(1);');
-    this.tree2 = program('bar.foo();');
-    this.tree3 = program('bar.doe.foo();');
-    this.tree4 = program('var a;');
-  });
+var Tree = require('../..');
 
-  describe('#tree.callExpression()', function () {
-    it('selects function call', function () {
-      assert.equal(this.tree1.callExpression('foo').length, 1);
+[
+  Tree.fromSource,
+  function() {
+    var tree = Tree.fromSource(arguments[0], arguments[1], arguments[2], arguments[3], arguments[4]);
+    return Tree.fromTree(tree.tree, arguments[1], arguments[2], arguments[3], arguments[4]);
+  },
+].forEach(function(program) {
+  describe('CallExpression objects', function () {
+    beforeEach(function () {
+      this.tree1 = program('foo(1);');
+      this.tree2 = program('bar.foo();');
+      this.tree3 = program('bar.doe.foo();');
+      this.tree4 = program('var a;');
     });
 
-    it('selects method call', function () {
-      assert.equal(this.tree2.callExpression('bar.foo').length, 1);
-      assert.equal(this.tree3.callExpression('bar.doe.foo').length, 1);
-    });
+    describe('#tree.callExpression()', function () {
+      it('selects function call', function () {
+        assert.equal(this.tree1.callExpression('foo').length, 1);
+      });
 
-    it('can match no node', function () {
-      assert.equal(this.tree4.callExpression('bar').length, 0);
-    });
+      it('selects method call', function () {
+        assert.equal(this.tree2.callExpression('bar.foo').length, 1);
+        assert.equal(this.tree3.callExpression('bar.doe.foo').length, 1);
+      });
 
-    it('can match function name by regex', function () {
-      var multiFnTree = program(
-          'selectedFn(1);' +
-          'object.property.selectedFn(1);' +
-          'notSelectedFn(1);'
-        ),
-        matchEveryFunction = /.+/;
+      it('can match no node', function () {
+        assert.equal(this.tree4.callExpression('bar').length, 0);
+      });
 
-      assert.equal(multiFnTree.callExpression(/(\.|^)selected/).length, 2);
-      assert.equal(multiFnTree.callExpression(matchEveryFunction).length, 3);
-    });
-  });
+      it('can match function name by regex', function () {
+        var multiFnTree = program(
+            'selectedFn(1);' +
+            'object.property.selectedFn(1);' +
+            'notSelectedFn(1);'
+          ),
+          matchEveryFunction = /.+/;
 
-  describe('#arguments', function () {
-    describe('#push()', function () {
-      it('add argument to the end', function () {
-        this.tree1.callExpression('foo').arguments.push('["a"]');
-        assert.equal(this.tree1.toString(), 'foo(1, [\'a\']);');
+        assert.equal(multiFnTree.callExpression(/(\.|^)selected/).length, 2);
+        assert.equal(multiFnTree.callExpression(matchEveryFunction).length, 3);
       });
     });
 
-    describe('#unshift()', function () {
-      it('add argument to the start', function () {
-        this.tree1.callExpression('foo').arguments.unshift('2');
-        assert.equal(this.tree1.toString(), 'foo(2, 1);');
-      });
-    });
-
-    describe('#at()', function () {
-      beforeEach(function () {
-        this.tree = program('foo(1, { a : "b" }, "foo", b);');
-      });
-
-      it('returns argument at given index', function () {
-        assert.equal(this.tree.callExpression('foo').arguments.at(0).value(), 1);
-        assert.equal(this.tree.callExpression('foo').arguments.at(2).value(), 'foo');
-      });
-
-      it('returns wrapped node', function () {
-        assert(this.tree.callExpression('foo').arguments.at(0) instanceof Literal);
-        assert(this.tree.callExpression('foo').arguments.at(1) instanceof ObjectExpression);
-      });
-    });
-
-    describe('#value()', function () {
-      beforeEach(function () {
-        this.tree = program('var foo = [1, 2, 3, 4];');
-      });
-
-      it('replaces itself with new value', function () {
-        var array = this.tree.var('foo').value();
-        var newArray = array.value('[8, 9]');
-        assert.equal(this.tree.var('foo').value().at(0).value(), 8);
-        assert.equal(this.tree.var('foo').value().at(1).value(), 9);
-        assert.throws(function () {
-          this.tree.var('foo').value().at(2).value();
+    describe('#arguments', function () {
+      describe('#push()', function () {
+        it('add argument to the end', function () {
+          this.tree1.callExpression('foo').arguments.push('["a"]');
+          assert.equal(this.tree1.toString(), 'foo(1, [\'a\']);');
         });
       });
 
-      it('returns the new value', function () {
-        var array = this.tree.var('foo').value();
-        var newArray = array.value('[1, 2]');
+      describe('#unshift()', function () {
+        it('add argument to the start', function () {
+          this.tree1.callExpression('foo').arguments.unshift('2');
+          assert.equal(this.tree1.toString(), 'foo(2, 1);');
+        });
+      });
+
+      describe('#at()', function () {
+        beforeEach(function () {
+          this.tree = program('foo(1, { a : "b" }, "foo", b);');
+        });
+
+        it('returns argument at given index', function () {
+          assert.equal(this.tree.callExpression('foo').arguments.at(0).value(), 1);
+          assert.equal(this.tree.callExpression('foo').arguments.at(2).value(), 'foo');
+        });
+
+        it('returns wrapped node', function () {
+          assert(this.tree.callExpression('foo').arguments.at(0) instanceof Literal);
+          assert(this.tree.callExpression('foo').arguments.at(1) instanceof ObjectExpression);
+        });
+      });
+
+      describe('#value()', function () {
+        beforeEach(function () {
+          this.tree = program('var foo = [1, 2, 3, 4];');
+        });
+
+        it('replaces itself with new value', function () {
+          var array = this.tree.var('foo').value();
+          var newArray = array.value('[8, 9]');
+          assert.equal(this.tree.var('foo').value().at(0).value(), 8);
+          assert.equal(this.tree.var('foo').value().at(1).value(), 9);
+          assert.throws(function () {
+            this.tree.var('foo').value().at(2).value();
+          });
+        });
+
+        it('returns the new value', function () {
+          var array = this.tree.var('foo').value();
+          var newArray = array.value('[1, 2]');
+        });
       });
     });
   });

--- a/test/nodes/variable.js
+++ b/test/nodes/variable.js
@@ -1,74 +1,83 @@
 /*globals describe, it, beforeEach */
 var assert = require('assert');
-var program = require('../..');
 
 var ObjectExpression = require('../../lib/nodes/ObjectExpression.js');
 var Literal = require('../../lib/nodes/Literal.js');
 
-describe('Variable objects', function () {
-  beforeEach(function () {
-    this.tree1 = program('var a = 1;');
-    this.tree2 = program('var a = 1, b = { a: "b" };');
-    this.tree3 = program('var a = 1; (function () { var a = 2; }());');
+var Tree = require('../..');
+
+[
+  Tree.fromSource,
+  function() {
+    var tree = Tree.fromSource(arguments[0], arguments[1], arguments[2], arguments[3], arguments[4]);
+    return Tree.fromTree(tree.tree, arguments[1], arguments[2], arguments[3], arguments[4]);
+  },
+].forEach(function(program) {
+  describe('Variable objects', function () {
+    beforeEach(function () {
+      this.tree1 = program('var a = 1;');
+      this.tree2 = program('var a = 1, b = { a: "b" };');
+      this.tree3 = program('var a = 1; (function () { var a = 2; }());');
+    });
+
+    describe('#tree.var()', function () {
+      it('string', function () {
+        assert.equal(this.tree1.var('a').length, 1);
+        assert.equal(this.tree3.var('a').length, 2);
+      });
+
+      it('supports regex', function () {
+        var multiVarTree = program(
+          'var selectedVar = 1;' +
+          'var selectedVar2 = 1;' +
+          'var unSelectedVar1 = 1;' +
+          'var unSelectedVar2 = 1;'
+        );
+
+        assert.equal(multiVarTree.var(/^selected[A-Z]+/).length, 2);
+      });
+    });
+
+    describe('#value()', function () {
+      it('update value', function () {
+        this.tree1.var('a').value('3');
+        assert.equal(this.tree1.toString(), 'var a = 3;');
+      });
+
+      it('update value (object)', function () {
+        this.tree1.var('a').value('{ foo: "bar" }');
+        assert.equal(this.tree1.toString(), 'var a = { foo: \'bar\' };');
+      });
+
+      it('update value when multiple declared var in a single block', function () {
+        this.tree2.var('b').value('3');
+        assert.equal(this.tree2.toString(), 'var a = 1, b = 3;');
+      });
+
+      it('update value of every matching variable', function () {
+        this.tree3.var('a').value('3');
+        assert.equal(this.tree3.toString(), 'var a = 3;\n(function () {\n    var a = 3;\n}());');
+      });
+
+      it('returns a wrapped value', function () {
+        assert(this.tree1.var('a').value() instanceof Literal);
+        assert(this.tree2.var('b').value() instanceof ObjectExpression);
+      });
+    });
+
+    describe('#rename()', function () {
+      it('rename the variable declaration', function () {
+        this.tree1.var('a').rename('foo');
+        assert.equal(this.tree1.toString(), 'var foo = 1;');
+      });
+    });
+
+    describe('#toString()', function () {
+      it('should preserve comments when assigning new values', function () {
+        this.tree1.var('a').value('{/* some comments */ foo: "bar" }');
+        assert.equal(this.tree1.toString().replace(/[\r\n\t\s]+/gm, ''), 'vara={/*somecomments*/foo:\'bar\'};');
+      });
+    });
+
   });
-
-  describe('#tree.var()', function () {
-    it('string', function () {
-      assert.equal(this.tree1.var('a').length, 1);
-      assert.equal(this.tree3.var('a').length, 2);
-    });
-
-    it('supports regex', function () {
-      var multiVarTree = program(
-        'var selectedVar = 1;' +
-        'var selectedVar2 = 1;' +
-        'var unSelectedVar1 = 1;' +
-        'var unSelectedVar2 = 1;'
-      );
-
-      assert.equal(multiVarTree.var(/^selected[A-Z]+/).length, 2);
-    });
-  });
-
-  describe('#value()', function () {
-    it('update value', function () {
-      this.tree1.var('a').value('3');
-      assert.equal(this.tree1.toString(), 'var a = 3;');
-    });
-
-    it('update value (object)', function () {
-      this.tree1.var('a').value('{ foo: "bar" }');
-      assert.equal(this.tree1.toString(), 'var a = { foo: \'bar\' };');
-    });
-
-    it('update value when multiple declared var in a single block', function () {
-      this.tree2.var('b').value('3');
-      assert.equal(this.tree2.toString(), 'var a = 1, b = 3;');
-    });
-
-    it('update value of every matching variable', function () {
-      this.tree3.var('a').value('3');
-      assert.equal(this.tree3.toString(), 'var a = 3;\n(function () {\n    var a = 3;\n}());');
-    });
-
-    it('returns a wrapped value', function () {
-      assert(this.tree1.var('a').value() instanceof Literal);
-      assert(this.tree2.var('b').value() instanceof ObjectExpression);
-    });
-  });
-
-  describe('#rename()', function () {
-    it('rename the variable declaration', function () {
-      this.tree1.var('a').rename('foo');
-      assert.equal(this.tree1.toString(), 'var foo = 1;');
-    });
-  });
-
-  describe('#toString()', function () {
-    it('should preserve comments when assigning new values', function () {
-      this.tree1.var('a').value('{/* some comments */ foo: "bar" }');
-      assert.equal(this.tree1.toString().replace(/[\r\n\t\s]+/gm, ''), 'vara={/*somecomments*/foo:\'bar\'};');
-    });
-  });
-
 });

--- a/test/tree.js
+++ b/test/tree.js
@@ -1,131 +1,140 @@
 var assert = require('assert');
-var program = require('..');
+var Tree = require('..');
 var Body = require('../lib/nodes/Body');
 
-describe('Tree', function () {
-  describe('#toString()', function () {
-    it('return the generated source code', function () {
-      var tree = program('var a = 1');
-      assert.equal(tree.toString(), 'var a = 1;');
+
+[
+  Tree.fromSource,
+  function() {
+    var tree = Tree.fromSource(arguments[0], arguments[1], arguments[2], arguments[3], arguments[4]);
+    return Tree.fromTree(tree.tree, arguments[1], arguments[2], arguments[3], arguments[4]);
+  },
+].forEach(function(program) {
+  describe('Tree', function () {
+    describe('#toString()', function () {
+      it('return the generated source code', function () {
+        var tree = program('var a = 1');
+        assert.equal(tree.toString(), 'var a = 1;');
+      });
     });
-  });
 
-  describe('#toString() - with comments', function () {
-    it('return the generated source code', function () {
-      var tree = program('/* comment */var a = 1');
-      assert.equal(tree.toString().replace(/[\r\n\t\s]+/gm, ''), '/*comment*/vara=1;');
+    describe('#toString() - with comments', function () {
+      it('return the generated source code', function () {
+        var tree = program('/* comment */var a = 1');
+        assert.equal(tree.toString().replace(/[\r\n\t\s]+/gm, ''), '/*comment*/vara=1;');
 
-      tree = program('var a = {\n/* comment */a:1};');
-      assert.equal(tree.toString().replace(/[\r\n\t\s]+/gm, ''), 'vara={/*comment*/a:1};');
+        tree = program('var a = {\n/* comment */a:1};');
+        assert.equal(tree.toString().replace(/[\r\n\t\s]+/gm, ''), 'vara={/*comment*/a:1};');
+      });
     });
-  });
 
-  describe('#body', function () {
-    it('is a Body node instance', function () {
-      var tree = program('var a = 1');
-      assert(tree.body instanceof Body);
+    describe('#body', function () {
+      it('is a Body node instance', function () {
+        var tree = program('var a = 1');
+        assert(tree.body instanceof Body);
+      });
     });
-  });
 
-  describe('created with default escodegen options', function () {
-    it('return the generated source code', function () {
-      var tree = program('(function () {\n\tconsole.log("foo");\n\tconsole.log("bar");\n})();');
-      assert.equal(tree.toString().charAt(15), ' ');
+    describe('created with default escodegen options', function () {
+      it('return the generated source code', function () {
+        var tree = program('(function () {\n\tconsole.log("foo");\n\tconsole.log("bar");\n})();');
+        assert.equal(tree.toString().charAt(15), ' ');
+      });
     });
-  });
 
-  describe('created with tab formatting escodegen option', function () {
-    it('return the generated source code', function () {
-      var tree = program('(function () {\n  console.log("foo");\n  console.log("bar");\n})();', {
-        format: {
-          indent: {
-            style: '\t'
+    describe('created with tab formatting escodegen option', function () {
+      it('return the generated source code', function () {
+        var tree = program('(function () {\n  console.log("foo");\n  console.log("bar");\n})();', {
+          format: {
+            indent: {
+              style: '\t'
+            }
           }
-        }
-      });
-      assert.equal(tree.toString().charAt(15), '\t');
-    });
-  });
-
-  describe('created with default esprima options', function () {
-    it('parses the source code as a script', function () {
-      assert.doesNotThrow(function () {
-        program('var a = 1;');
-      }, Error);
-    });
-    it('does not parse the source code as a module', function () {
-      assert.throws(function () {
-        program('var a = 1;\nexport default a;');
-      }, Error);
-    });
-  });
-
-  describe('created with es2015 module esprima options', function () {
-    it('does not parse the module source code when the sourceType configuration is missing', function () {
-      assert.throws(function () {
-        program('var a = 1;\nexport default a;');
-      }, Error);
-    });
-
-    it('parses the source code as a module when the sourceType configuration is present', function () {
-      assert.doesNotThrow(function () {
-        program('var a = 1;\nexport default a;', {}, { sourceType: 'module' });
+        });
+        assert.equal(tree.toString().charAt(15), '\t');
       });
     });
-  });
 
-  describe('created with jsx acron options', function () {
-    it('does not parse the jsx source code when the jsx configuration is missing', function () {
-      assert.throws(function () {
-        program('(function () {\n return (<div>body</div>);\n })();');
-      }, Error);
-    });
-
-    // it('parses the jsx source code when the jsx configuration is present', function () {
-    //   assert.doesNotThrow(function () {
-    //     var tree = program('(function () {\n return (<div>body</div>);\n })();', {}, { plugins: { jsx: {} } });
-    //   });
-    // });
-
-    it('parses the jsx source code when the jsx configuration is present when appended', function () {
-      assert.doesNotThrow(function () {
-        var tree = program('', {}, { plugins: { jsx: {} } });
-        tree.body.append('(function () {\n return (<div>body</div>);\n })();');
+    describe('created with default esprima options', function () {
+      it('parses the source code as a script', function () {
+        assert.doesNotThrow(function () {
+          program('var a = 1;');
+        }, Error);
+      });
+      it('does not parse the source code as a module', function () {
+        assert.throws(function () {
+          program('var a = 1;\nexport default a;');
+        }, Error);
       });
     });
+
+    describe('created with es2015 module esprima options', function () {
+      it('does not parse the module source code when the sourceType configuration is missing', function () {
+        assert.throws(function () {
+          program('var a = 1;\nexport default a;');
+        }, Error);
+      });
+
+      it('parses the source code as a module when the sourceType configuration is present', function () {
+        assert.doesNotThrow(function () {
+          program('var a = 1;\nexport default a;', {}, { sourceType: 'module' });
+        });
+      });
+    });
+
+    describe('created with jsx acron options', function () {
+      it('does not parse the jsx source code when the jsx configuration is missing', function () {
+        assert.throws(function () {
+          program('(function () {\n return (<div>body</div>);\n })();');
+        }, Error);
+      });
+
+      // it('parses the jsx source code when the jsx configuration is present', function () {
+      //   assert.doesNotThrow(function () {
+      //     var tree = program('(function () {\n return (<div>body</div>);\n })();', {}, { plugins: { jsx: {} } });
+      //   });
+      // });
+
+      it('parses the jsx source code when the jsx configuration is present when appended', function () {
+        assert.doesNotThrow(function () {
+          var tree = program('', {}, { plugins: { jsx: {} } });
+          tree.body.append('(function () {\n return (<div>body</div>);\n })();');
+        });
+      });
+    });
+
+    describe('#verbatim() - without using', function () {
+      it('does not error', function () {
+        var tree = program('var a = 1');
+        tree.verbatim('ANYTHING');
+      });
+    });
+
+    describe('#verbatim() - used as replacement', function () {
+      it('return the generated source code when appended', function () {
+        var tree = program('var a = 1');
+        tree.body.append(tree.verbatim('ANYTHING'));
+        assert.equal(tree.toString(), 'var a = 1;\nANYTHING;');
+      });
+
+      it('return the generated source code when appended multiple times', function () {
+        var tree = program('var a = 1');
+        tree.body.append(tree.verbatim('ANYTHING1') + tree.verbatim('ANYTHING2') + tree.verbatim('ANYTHING3'));
+        assert.equal(tree.toString(), 'var a = 1;\nANYTHING1;\nANYTHING2;\nANYTHING3;');
+      });
+
+      it('return the generated source code when appended with values', function () {
+        var tree = program('var a = 1');
+        tree.body.append('before = ' + tree.verbatim('ANYTHING'));
+        assert.equal(tree.toString(), 'var a = 1;\nbefore = (ANYTHING);');
+      });
+
+      it('return the generated source code when prepended', function () {
+        var tree = program('var a = 1');
+        tree.body.prepend(tree.verbatim('ANYTHING'));
+        assert.equal(tree.toString(), 'ANYTHING;\nvar a = 1;');
+      });
+    });
+
   });
-
-  describe('#verbatim() - without using', function () {
-    it('does not error', function () {
-      var tree = program('var a = 1');
-      tree.verbatim('ANYTHING');
-    });
-  });
-
-  describe('#verbatim() - used as replacement', function () {
-    it('return the generated source code when appended', function () {
-      var tree = program('var a = 1');
-      tree.body.append(tree.verbatim('ANYTHING'));
-      assert.equal(tree.toString(), 'var a = 1;\nANYTHING;');
-    });
-
-    it('return the generated source code when appended multiple times', function () {
-      var tree = program('var a = 1');
-      tree.body.append(tree.verbatim('ANYTHING1') + tree.verbatim('ANYTHING2') + tree.verbatim('ANYTHING3'));
-      assert.equal(tree.toString(), 'var a = 1;\nANYTHING1;\nANYTHING2;\nANYTHING3;');
-    });
-
-    it('return the generated source code when appended with values', function () {
-      var tree = program('var a = 1');
-      tree.body.append('before = ' + tree.verbatim('ANYTHING'));
-      assert.equal(tree.toString(), 'var a = 1;\nbefore = (ANYTHING);');
-    });
-
-    it('return the generated source code when prepended', function () {
-      var tree = program('var a = 1');
-      tree.body.prepend(tree.verbatim('ANYTHING'));
-      assert.equal(tree.toString(), 'ANYTHING;\nvar a = 1;');
-    });
-  });
-
 });


### PR DESCRIPTION
Exposed the Tree obj
Added `Tree.fromTree` and `Tree.fromSource` constructors
Allows a Tree to be created from an existing ast instead of only from a source string

Breaks backwards compatibility, so could you please let me know how you would like to integrate this?